### PR TITLE
Add component parameter for custom composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,29 +28,29 @@ import MultiProgress, { IMultiProgressProps } from 'react-multi-progress'
 
 ## Available props
 
-| Attribute                  |         Type          | Optional |         Default         | Description                                                                                                                                                                                                      |
-| :------------------------- | :-------------------: | :------: | :---------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| backgroundColor            |       `string`        |   yes    |        `#ffffff`        | Background color of the progress bar                                                                                                                                                                             |
-| border                     |       `string`        |   yes    |         `none`          | set a border around the progress bar, e.g. `1px solid red`                                                                                                                                                       |
-| elements                   |  `ProgressElement[]`  |    no    |         `none`          | Set the color and size of each element, see "ProgressElement" below.                                                                                                                                             |
-| height                     |       `number`        |   yes    |          `10`           | Height of the progress bar in `px`                                                                                                                                                                               |
-| round                      |        `bool`         |   yes    |         `true`          | Wheter the ends of the progress bar container should be rounded                                                                                                                                                  |
-| roundLastElement           |        `bool`         |   yes    |         `true`          | Wheter the last progress element should be rounded on the right end                                                                                                                                              |
-| transitionTime             |       `number`        |   yes    |          `0.6`          | Transition time in seconds to animate when the value changes. Set to `0` for no animation.                                                                                                                       |
-| className                  |       `string`        |   yes    |                         | CSS className passed onto the ProgressBar Container                                                                                                                                                              |
-| component                  |     `ElementType`     |   yes    |          `div`          | Custom element used to render progress elements, either a HTML tag name or React component accepting `className`, `style`, `children`, and `element` props, with `element` being the `ProgressElement` passed in |
-| type generic (see example) | `Record<string, any>` |   yes    | `Record<string, never>` | Additional props to add to the definition of `elements`, for use with custom components                                                                                                                          |
+| Attribute									|				 Type					| Optional |				 Default				 | Description																																																																																																																																																									|
+| :------------------------- | :-------------------: | :------: | :---------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| backgroundColor						|			 `string`				|	 yes		|				`#ffffff`				| Background color of the progress bar																																																																																																																																												 |
+| border										 |			 `string`				|	 yes		|				 `none`					| set a border around the progress bar, e.g. `1px solid red`																																																																																																																																	 |
+| elements									 |	`ProgressElement[]`	|		no		|				 `none`					| Set the color and size of each element, see "ProgressElement" below.																																																																																																																												 |
+| height										 |			 `number`				|	 yes		|					`10`					 | Height of the progress bar in `px`																																																																																																																																													 |
+| round											|				`bool`				 |	 yes		|				 `true`					| Wheter the ends of the progress bar container should be rounded																																																																																																																															|
+| roundLastElement					 |				`bool`				 |	 yes		|				 `true`					| Wheter the last progress element should be rounded on the right end																																																																																																																													|
+| transitionTime						 |			 `number`				|	 yes		|					`0.6`					| Transition time in seconds to animate when the value changes. Set to `0` for no animation.																																																																																																																	 |
+| className									|			 `string`				|	 yes		|												 | CSS className passed onto the ProgressBar Container																																																																																																																																					|
+| component									|		 `ElementType`		 |	 yes		|					`div`					| Custom element used to render progress elements, either a HTML tag name or React component accepting `className`, `children`, and `element` props, with `element` being the `ProgressElement` passed in. Be sure to spread the remaining props (see example) as style information is provided in this way (a data attribute) |
+| type generic (see example) | `Record<string, any>` |	 yes		| `Record<string, never>` | Additional props to add to the definition of `elements`, for use with custom components																																																																																																																			|
 
 ### ProgressElement
 
-| Attribute      |   Type   | Optional | Description                                              |
+| Attribute			|	 Type	 | Optional | Description																							|
 | :------------- | :------: | :------: | :------------------------------------------------------- |
-| value          | `number` |    no    | Length of the element in % (0-100)                       |
-| color          | `string` |    no    | Color of the element (any css compatible format)         |
-| showPercentage |  `bool`  |   yes    | Show the percentage as text in the ProgressElement       |
-| textColor      | `string` |   yes    | Color of the percentage text (any css compatible format) |
-| fontSize       | `number` |   yes    | font size of the percentage text (in px)                 |
-| className      | `string` |   yes    | CSS className passed onto the ProgressElement            |
+| value					| `number` |		no		| Length of the element in % (0-100)											 |
+| color					| `string` |		no		| Color of the element (any css compatible format)				 |
+| showPercentage |	`bool`	|	 yes		| Show the percentage as text in the ProgressElement			 |
+| textColor			| `string` |	 yes		| Color of the percentage text (any css compatible format) |
+| fontSize			 | `number` |	 yes		| font size of the percentage text (in px)								 |
+| className			| `string` |	 yes		| CSS className passed onto the ProgressElement						|
 
 ## Example
 
@@ -81,12 +81,18 @@ import MultiProgress, { ProgressComponentProps } from "react-multi-progress";
 // for non-TS projects, remove this and other types
 type ExtraData = { isBold: boolean };
 
-function CustomComponent(props: ProgressComponentProps<ExtraData>) {
+function CustomComponent({
+	children,
+	element,
+	...rest
+}: ProgressComponentProps<ExtraData>) {
 	return (
-		<div className={props.className} style={{
-			...props.style,
-			fontWeight: props.element.isBold ? "bolder" : undefined
-		}}>
+		<div
+			{...rest} // adds all styles for rendering the progress bar
+			style={{
+				fontWeight: props.element.isBold ? "bolder" : undefined,
+			}}
+		>
 			{props.children}
 		</div>
 	);

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ function Progress() {
 ### Advanced
 
 ```tsx
-import MultiProgress from "react-multi-progress";
+import MultiProgress, { ProgressComponentProps } from "react-multi-progress";
 
 // for non-TS projects, remove this and other types
-type ExtraData = {isBold: boolean};
+type ExtraData = { isBold: boolean };
 
 function CustomComponent(props: ProgressComponentProps<ExtraData>) {
 	return (

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ![alt text](docs/progressbar.png)
 
-A simple, typed react progress bar that allowes multiple layers in different colors. [Demo](http://progress.bitter.li)
+A simple, typed react progress bar that allowes multiple layers in different
+colors. [Demo](http://progress.bitter.li)
 
 ## Installation
 
@@ -10,7 +11,8 @@ Install with npm:
 
 - `npm install react-multi-progress --save`
 
-You can now import `react-multi-progress` as a normal package installed from npm like so:
+You can now import `react-multi-progress` as a normal package installed from npm
+like so:
 
 ```
 import MultiProgress from 'react-multi-progress'
@@ -26,16 +28,18 @@ import MultiProgress, { IMultiProgressProps } from 'react-multi-progress'
 
 ## Available props
 
-| Attribute        |        Type         | Optional |  Default  | Description                                                                                |
-| :--------------- | :-----------------: | :------: | :-------: | ------------------------------------------------------------------------------------------ |
-| backgroundColor  |      `string`       |   yes    | `#ffffff` | Background color of the progress bar                                                       |
-| border           |      `string`       |   yes    |  `none`   | set a border around the progress bar, e.g. `1px solid red`                                 |
-| elements         | `ProgressElement[]` |    no    |  `none`   | Set the color and size of each element, see "ProgressElement" below.                       |
-| height           |      `number`       |   yes    |   `10`    | Height of the progress bar in `px`                                                         |
-| round            |       `bool`        |   yes    |  `true`   | Wheter the ends of the progress bar container should be rounded                            |
-| roundLastElement |       `bool`        |   yes    |  `true`   | Wheter the last progress element should be rounded on the right end                        |
-| transitionTime   |      `number`       |   yes    |   `0.6`   | Transition time in seconds to animate when the value changes. Set to `0` for no animation. |
-| className        |      `string`       |   yes    |           | CSS className passed onto the ProgressBar Container                                        |
+| Attribute                  |         Type          | Optional |         Default         | Description                                                                                                                                                                                                      |
+| :------------------------- | :-------------------: | :------: | :---------------------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| backgroundColor            |       `string`        |   yes    |        `#ffffff`        | Background color of the progress bar                                                                                                                                                                             |
+| border                     |       `string`        |   yes    |         `none`          | set a border around the progress bar, e.g. `1px solid red`                                                                                                                                                       |
+| elements                   |  `ProgressElement[]`  |    no    |         `none`          | Set the color and size of each element, see "ProgressElement" below.                                                                                                                                             |
+| height                     |       `number`        |   yes    |          `10`           | Height of the progress bar in `px`                                                                                                                                                                               |
+| round                      |        `bool`         |   yes    |         `true`          | Wheter the ends of the progress bar container should be rounded                                                                                                                                                  |
+| roundLastElement           |        `bool`         |   yes    |         `true`          | Wheter the last progress element should be rounded on the right end                                                                                                                                              |
+| transitionTime             |       `number`        |   yes    |          `0.6`          | Transition time in seconds to animate when the value changes. Set to `0` for no animation.                                                                                                                       |
+| className                  |       `string`        |   yes    |                         | CSS className passed onto the ProgressBar Container                                                                                                                                                              |
+| component                  |     `ElementType`     |   yes    |          `div`          | Custom element used to render progress elements, either a HTML tag name or React component accepting `className`, `style`, `children`, and `element` props, with `element` being the `ProgressElement` passed in |
+| type generic (see example) | `Record<string, any>` |   yes    | `Record<string, never>` | Additional props to add to the definition of `elements`, for use with custom components                                                                                                                          |
 
 ### ProgressElement
 
@@ -71,21 +75,37 @@ function Progress() {
 
 ### Advanced
 
-```jsx
+```tsx
 import MultiProgress from "react-multi-progress";
+
+// for non-TS projects, remove this and other types
+type ExtraData = {isBold: boolean};
+
+function CustomComponent(props: ProgressComponentProps<ExtraData>) {
+	return (
+		<div className={props.className} style={{
+			...props.style,
+			fontWeight: props.element.isBold ? "bolder" : undefined
+		}}>
+			{props.children}
+		</div>
+	);
+}
 
 function Progress() {
 	return (
-		<MultiProgress
+		<MultiProgress<ExtraData>
 			transitionTime={1.2}
 			elements={[
 				{
 					value: 15,
 					color: "blue",
+					isBold: false,
 				},
 				{
 					value: 35,
 					color: "rgb(100,0,0)",
+					isBold: true,
 				},
 				{
 					value: 25,
@@ -94,12 +114,14 @@ function Progress() {
 					textColor: "black",
 					fontSize: 12,
 					className: "my-custom-css-class",
+					isBold: false,
 				},
 			]}
 			height={15}
 			backgroundColor="gray"
-			border={"1px solid red"}
+			border="1px solid red"
 			className="my-custom-css-class"
+			component={CustomComponent}
 		/>
 	);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "react-multi-progress",
-	"version": "1.1.5",
+	"version": "1.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "react-multi-progress",
-			"version": "1.1.5",
+			"version": "1.2.0",
 			"license": "ISC",
 			"dependencies": {
 				"glamor": "^2.20.40"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -91,7 +91,7 @@ function createElementArray<T>(
 	component: IMultiProgressProps<T>["component"]
 ) {
 	let currentOffset = 0;
-	let newElements = [] as any[];
+	let newElements: React.ReactNode[] = [];
 
 	const Element = component ?? "div";
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,11 +11,10 @@ export interface ProgressElement {
 }
 
 export type ProgressComponentProps<T> = {
-	style?: React.CSSProperties,
 	children?: React.ReactNode,
 	className?: string,
 	element: (ProgressElement & T)
-};
+} & Record<string, unknown>;
 
 export type IMultiProgressProps<T> = {
 	backgroundColor?: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,11 @@ export type IMultiProgressProps = {
 	roundLastElement?: boolean;
 	transitionTime?: number;
 	className?: string;
+	Component?: React.ElementType<{
+		style?: React.CSSProperties,
+		children?: React.ReactNode,
+		className?: string
+	}>
 };
 const styles = {
 	progressContainer: (
@@ -80,14 +85,17 @@ const styles = {
 const createElementArray = (
 	elements: ProgressElement[],
 	transitionTime: number,
-	roundLastElement: boolean
+	roundLastElement: boolean,
+	Component: IMultiProgressProps["Component"]
 ) => {
 	let currentOffset = 0;
 	let newElements = [] as any[];
 
+	const Element = Component ?? "div";
+
 	elements.forEach((element, i) => {
 		newElements.push(
-			<div
+			<Element
 				{...styles.progressElement(
 					element.color,
 					currentOffset,
@@ -101,7 +109,7 @@ const createElementArray = (
 				className={element.className}
 			>
 				{element.showPercentage && `${element.value}%`}
-			</div>
+			</Element>
 		);
 		currentOffset += element.value;
 	});
@@ -117,6 +125,7 @@ const MultiProgress: React.FC<IMultiProgressProps> = ({
 	roundLastElement = true,
 	transitionTime = 0.6,
 	className,
+	Component
 }) => {
 	return (
 		<div
@@ -124,7 +133,7 @@ const MultiProgress: React.FC<IMultiProgressProps> = ({
 			className={className}
 		>
 			<div {...styles.progressBackground(backgroundColor)} />
-			{createElementArray(elements, transitionTime, roundLastElement).map(
+			{createElementArray(elements, transitionTime, roundLastElement, Component).map(
 				(element, i) => (
 					<div key={i}>{element}</div>
 				)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { css } from "glamor";
 
-interface ProgressElement {
+export interface ProgressElement {
 	value: number;
 	color: string;
 	showPercentage?: boolean;
@@ -10,20 +10,23 @@ interface ProgressElement {
 	className?: string;
 }
 
-export type IMultiProgressProps = {
+export type ProgressComponentProps<T> = {
+	style?: React.CSSProperties,
+	children?: React.ReactNode,
+	className?: string,
+	element: (ProgressElement & T)
+};
+
+export type IMultiProgressProps<T> = {
 	backgroundColor?: string;
 	border?: string;
-	elements: ProgressElement[];
+	elements: (ProgressElement & T)[];
 	height?: number | string;
 	round?: boolean;
 	roundLastElement?: boolean;
 	transitionTime?: number;
 	className?: string;
-	Component?: React.ElementType<{
-		style?: React.CSSProperties,
-		children?: React.ReactNode,
-		className?: string
-	}>
+	component?: React.ElementType<ProgressComponentProps<T>>
 };
 const styles = {
 	progressContainer: (
@@ -82,16 +85,16 @@ const styles = {
 	},
 };
 
-const createElementArray = (
-	elements: ProgressElement[],
+function createElementArray<T>(
+	elements: (T & ProgressElement)[],
 	transitionTime: number,
 	roundLastElement: boolean,
-	Component: IMultiProgressProps["Component"]
-) => {
+	component: IMultiProgressProps<T>["component"]
+) {
 	let currentOffset = 0;
 	let newElements = [] as any[];
 
-	const Element = Component ?? "div";
+	const Element = component ?? "div";
 
 	elements.forEach((element, i) => {
 		newElements.push(
@@ -107,6 +110,7 @@ const createElementArray = (
 				)}
 				key={i}
 				className={element.className}
+				element={element}
 			>
 				{element.showPercentage && `${element.value}%`}
 			</Element>
@@ -114,9 +118,9 @@ const createElementArray = (
 		currentOffset += element.value;
 	});
 	return newElements;
-};
+}
 
-const MultiProgress: React.FC<IMultiProgressProps> = ({
+export default function MultiProgress<T = Record<string, never>>({
 	backgroundColor = "#ffffff",
 	border = "",
 	elements,
@@ -125,21 +129,19 @@ const MultiProgress: React.FC<IMultiProgressProps> = ({
 	roundLastElement = true,
 	transitionTime = 0.6,
 	className,
-	Component
-}) => {
+	component
+}: IMultiProgressProps<T>) {
 	return (
 		<div
 			{...styles.progressContainer(round, height, border)}
 			className={className}
 		>
 			<div {...styles.progressBackground(backgroundColor)} />
-			{createElementArray(elements, transitionTime, roundLastElement, Component).map(
+			{createElementArray(elements, transitionTime, roundLastElement, component).map(
 				(element, i) => (
 					<div key={i}>{element}</div>
 				)
 			)}
 		</div>
 	);
-};
-
-export default MultiProgress;
+}


### PR DESCRIPTION
This PR adds support for a custom prop, `Component`, to be provided to override the default `<div>` used for each progress piece.  This will default to `<div>` when nothing is provided (current behavior), however, with this custom component users can more powerfully control the rendered progress pieces.

This allows a range of extra features, such as injecting special text, adding extra CSS, (in my case) wrapping each piece with a tooltip component, or any other customization.

Also, the PR includes a change to `package-lock.json` to reflect the package's current version.